### PR TITLE
bugfix : use streamer as weak ref

### DIFF
--- a/src/DOUAudioEventLoop.m
+++ b/src/DOUAudioEventLoop.m
@@ -460,7 +460,7 @@ static void audio_route_change_listener(void *inClientData,
 
 - (void)_eventLoop
 {
-  DOUAudioStreamer *streamer = nil;
+  __weak DOUAudioStreamer *streamer = nil;
 
   while (1) {
     @autoreleasepool {


### PR DESCRIPTION
umeng 上看到的crash, 应该是野指针了

*\* -[DOUAudioStreamer setStatus:]: unrecognized selector sent to instance 0x156a7370 **
xcrun atos -o DoubanRadio -arch armv7 0x13c78f
-[DOUAudioEventLoop _handleEvent:withStreamer:](in DoubanRadio) + 1007
-[DOUAudioStreamer setStatus:]: unrecognized selector sent to instance 0x156a7370
