### PR TITLE
Audio session category should be setted before initialize AudioComponentInstance

### DIFF
--- a/src/DOUAudioEventLoop.m
+++ b/src/DOUAudioEventLoop.m
@@ -92,6 +92,11 @@ typedef NS_ENUM(uint64_t, event_type) {
     _kq = kqueue();
     pthread_mutex_init(&_mutex, NULL);
 
+#if TARGET_OS_IPHONE
+    // Audio session should be setup before `AudioComponentInstance` is initialized.
+    [self _setupAudioSession];
+#endif /* TARGET_OS_IPHONE */
+
     _renderer = [DOUAudioRenderer rendererWithBufferTime:kDOUAudioStreamerBufferTime];
     [_renderer setUp];
 
@@ -103,9 +108,7 @@ typedef NS_ENUM(uint64_t, event_type) {
     }
 
     _decoderBufferSize = [[self class] _decoderBufferSize];
-#if TARGET_OS_IPHONE
-    [self _setupAudioSession];
-#endif /* TARGET_OS_IPHONE */
+
     [self _setupFileProviderEventBlock];
     [self _enableEvents];
     [self _createThread];


### PR DESCRIPTION
目前有这样的 bug：如果应用在启动时播放音频，并且在启动时立即按 Home 键让应用进入后台，这时 AudioStreamer 无法播放音频。原因是 `AudioUnitInitialize` 返回了 `AVAudioSessionErrorCodeCannotStartPlaying` 错误（iOS 7 上会返回这个错误，iOS 7 之前会返回一个不知道什么状态的错误）。

根据文档这个错误通常是指「无法在后台播放」。看了代码，发现在调用 `AudioUnitInitialize` 之前并没有把 audio session category 设置为 `kAudioSessionCategory_MediaPlayback`，也就是此时还是默认的 `kAudioSessionCategory_SoloAmbientSound`，而这个 category 是不允许在后台播放的。所以也就导致了 `AudioUnitInitialize` 出错。

这里的改动把 `DOUAudioEventLoop` 中设置 audio session category 的调用放到了初始化 `DOUAudioRenderer` 之前，解决了这个问题。
