### PR TITLE
fix(lpcm): replace OSSpinLock with pthread mutex

### DIFF
--- a/src/DOUAudioLPCM.m
+++ b/src/DOUAudioLPCM.m
@@ -15,7 +15,7 @@
  */
 
 #import "DOUAudioLPCM.h"
-#include <libkern/OSAtomic.h>
+#include <pthread.h>
 
 typedef struct data_segment {
   void *bytes;
@@ -27,7 +27,7 @@ typedef struct data_segment {
 @private
   data_segment *_segments;
   BOOL _end;
-  OSSpinLock _lock;
+  pthread_mutex_t _lock;
 }
 @end
 
@@ -39,7 +39,7 @@ typedef struct data_segment {
 {
   self = [super init];
   if (self) {
-    _lock = OS_SPINLOCK_INIT;
+    pthread_mutex_init(&_lock, NULL);
   }
 
   return self;
@@ -52,15 +52,17 @@ typedef struct data_segment {
     free(_segments);
     _segments = next;
   }
+
+  pthread_mutex_destroy(&_lock);
 }
 
 - (void)setEnd:(BOOL)end
 {
-  OSSpinLockLock(&_lock);
+  pthread_mutex_lock(&_lock);
   if (end && !_end) {
     _end = YES;
   }
-  OSSpinLockUnlock(&_lock);
+  pthread_mutex_unlock(&_lock);
 }
 
 - (BOOL)readBytes:(void **)bytes length:(NSUInteger *)length
@@ -68,10 +70,10 @@ typedef struct data_segment {
   *bytes = NULL;
   *length = 0;
 
-  OSSpinLockLock(&_lock);
+  pthread_mutex_lock(&_lock);
 
   if (_end && _segments == NULL) {
-    OSSpinLockUnlock(&_lock);
+    pthread_mutex_unlock(&_lock);
     return NO;
   }
 
@@ -85,22 +87,22 @@ typedef struct data_segment {
     _segments = next;
   }
 
-  OSSpinLockUnlock(&_lock);
+  pthread_mutex_unlock(&_lock);
 
   return YES;
 }
 
 - (void)writeBytes:(const void *)bytes length:(NSUInteger)length
 {
-  OSSpinLockLock(&_lock);
+  pthread_mutex_lock(&_lock);
 
   if (_end) {
-    OSSpinLockUnlock(&_lock);
+    pthread_mutex_unlock(&_lock);
     return;
   }
 
   if (bytes == NULL || length == 0) {
-    OSSpinLockUnlock(&_lock);
+    pthread_mutex_unlock(&_lock);
     return;
   }
 
@@ -118,7 +120,7 @@ typedef struct data_segment {
 
   *link = segment;
 
-  OSSpinLockUnlock(&_lock);
+  pthread_mutex_unlock(&_lock);
 }
 
 @end


### PR DESCRIPTION
## 变更摘要
- 将 `DOUAudioLPCM` 内部并发锁从 `OSSpinLock` 替换为 `pthread_mutex_t`。
- 对应替换初始化、加锁/解锁与销毁逻辑，保持原有读写与结束标记语义不变。

## 变更动机
- `OSSpinLock` 已不推荐使用，存在优先级反转等问题。
- 使用 `pthread_mutex` 可以提供更安全、可维护的线程同步方案。

## 影响范围
- 仅修改 `src/DOUAudioLPCM.m`。
- 不涉及外部 API、数据结构协议或配置项变更。

## 测试说明
- 按当前流程未在本地额外执行测试，测试结果依赖 PR CI。

## 风险与回滚
- 风险：在高竞争场景下，互斥锁调度行为与自旋锁不同，可能带来轻微性能差异。
- 回滚：如发现异常，可回滚该提交恢复原同步实现。

## Reviewer 关注点
- 重点确认 `readBytes`、`writeBytes`、`setEnd` 的并发语义与原行为一致。
- 重点确认 `dealloc` 中互斥锁销毁时机与对象生命周期无冲突。
